### PR TITLE
feat(builders): add personal page for 0x8361F8… (closes #9)

### DIFF
--- a/packages/nextjs/app/builders/0x8361F86930Eb48f8AA67e86e190dDD7B230E7777/page.tsx
+++ b/packages/nextjs/app/builders/0x8361F86930Eb48f8AA67e86e190dDD7B230E7777/page.tsx
@@ -1,5 +1,7 @@
+import Image from "next/image";
 import Link from "next/link";
-import type { Metadata } from "next";
+import type { Metadata, NextPage } from "next";
+import { Address } from "~~/components/scaffold-eth";
 
 export const metadata: Metadata = {
   title: "Miguel — Batch #20",
@@ -8,27 +10,25 @@ export const metadata: Metadata = {
 
 const ADDR = "0x8361F86930Eb48f8AA67e86e190dDD7B230E7777";
 
-function short(a: string) {
-  return `${a.slice(0, 6)}…${a.slice(-4)}`;
-}
-
-export default function BuilderPage() {
+const MiguelBuilderPage: NextPage = () => {
   return (
     <main className="mx-auto max-w-3xl p-6">
-      <section className="rounded-2xl border shadow p-6 bg-gradient-to-b from-zinc-900 to-zinc-950 text-zinc-100">
+      <section className="rounded-2xl border shadow p-6 bg-gradient-to-b from-zinc-50 to-zinc-100 dark:from-zinc-900 dark:to-zinc-950 text-zinc-900 dark:text-zinc-100 border-zinc-200 dark:border-zinc-700">
         <div className="flex items-center gap-5">
-          <img
+          <Image
             src="https://github.com/migarci2.png?size=200"
             alt="avatar"
+            width={80}
+            height={80}
             className="w-20 h-20 rounded-full border border-zinc-700"
           />
           <div>
-            <h1 className="text-2xl font-semibold">Miguel García</h1>
-            <p className="text-sm text-zinc-400">Batch #20 — Builder</p>
-            <p className="text-sm mt-1 font-mono text-zinc-300">{ADDR}</p>
+            <h1 className="text-2xl font-semibold text-zinc-900 dark:text-zinc-100">Miguel García</h1>
+            <p className="text-sm text-zinc-600 dark:text-zinc-400">Batch #20 — Builder</p>
+            <Address address={ADDR} />
             <div className="mt-3 flex flex-wrap gap-2">
               <a
-                className="px-3 py-1 rounded-xl border border-zinc-700 hover:bg-zinc-800 transition"
+                className="px-3 py-1 rounded-xl border border-zinc-300 dark:border-zinc-700 hover:bg-zinc-100 dark:hover:bg-zinc-800 transition"
                 href={`https://arbiscan.io/address/${ADDR}`}
                 target="_blank"
                 rel="noreferrer"
@@ -36,7 +36,7 @@ export default function BuilderPage() {
                 View on Arbiscan
               </a>
               <a
-                className="px-3 py-1 rounded-xl border border-zinc-700 hover:bg-zinc-800 transition"
+                className="px-3 py-1 rounded-xl border border-zinc-300 dark:border-zinc-700 hover:bg-zinc-100 dark:hover:bg-zinc-800 transition"
                 href="https://github.com/migarci2"
                 target="_blank"
                 rel="noreferrer"
@@ -44,7 +44,7 @@ export default function BuilderPage() {
                 GitHub
               </a>
               <a
-                className="px-3 py-1 rounded-xl border border-zinc-700 hover:bg-zinc-800 transition"
+                className="px-3 py-1 rounded-xl border border-zinc-300 dark:border-zinc-700 hover:bg-zinc-100 dark:hover:bg-zinc-800 transition"
                 href="https://x.com/m1guelgr8"
                 target="_blank"
                 rel="noreferrer"
@@ -55,39 +55,32 @@ export default function BuilderPage() {
           </div>
         </div>
 
-        <p className="mt-5 text-zinc-200">
+        <p className="mt-5 text-zinc-700 dark:text-zinc-200">
           Computer Engineering student passionate about low-level systems, kernel development, DeFi, and AI. I enjoy
           building fast, useful, and optimized tools.
         </p>
 
         <div className="mt-6">
-          <h2 className="text-sm uppercase tracking-wider text-zinc-400">Focus Areas</h2>
+          <h2 className="text-sm uppercase tracking-wider text-zinc-500 dark:text-zinc-400">Focus Areas</h2>
           <div className="mt-2 flex flex-wrap gap-2">
-            <span className="text-xs px-2 py-1 rounded-full border border-zinc-700">Security</span>
-            <span className="text-xs px-2 py-1 rounded-full border border-zinc-700">Linux Internals</span>
-            <span className="text-xs px-2 py-1 rounded-full border border-zinc-700">Smart Contracts</span>
-            <span className="text-xs px-2 py-1 rounded-full border border-zinc-700">AI/ML</span>
+            <span className="text-xs px-2 py-1 rounded-full border border-zinc-300 dark:border-zinc-700 bg-zinc-100 dark:bg-zinc-800 text-zinc-700 dark:text-zinc-300">
+              Security
+            </span>
+            <span className="text-xs px-2 py-1 rounded-full border border-zinc-300 dark:border-zinc-700 bg-zinc-100 dark:bg-zinc-800 text-zinc-700 dark:text-zinc-300">
+              Linux Internals
+            </span>
+            <span className="text-xs px-2 py-1 rounded-full border border-zinc-300 dark:border-zinc-700 bg-zinc-100 dark:bg-zinc-800 text-zinc-700 dark:text-zinc-300">
+              Smart Contracts
+            </span>
+            <span className="text-xs px-2 py-1 rounded-full border border-zinc-300 dark:border-zinc-700 bg-zinc-100 dark:bg-zinc-800 text-zinc-700 dark:text-zinc-300">
+              AI/ML
+            </span>
           </div>
         </div>
 
         <div className="mt-6 grid grid-cols-1 md:grid-cols-2 gap-4">
-          <div className="rounded-xl border border-zinc-800 p-4">
-            <h3 className="font-medium">On-chain</h3>
-            <ul className="mt-2 space-y-1 text-sm text-zinc-300">
-              <li>
-                Address:{" "}
-                <a className="underline" href={`https://arbiscan.io/address/${ADDR}`} target="_blank" rel="noreferrer">
-                  {short(ADDR)}
-                </a>
-              </li>
-              <li>
-                Network: <span className="text-zinc-400">Arbitrum</span>
-              </li>
-            </ul>
-          </div>
-
-          <div className="rounded-xl border border-zinc-800 p-4">
-            <h3 className="font-medium">Links</h3>
+          <div className="rounded-xl border border-zinc-300 dark:border-zinc-800 p-4">
+            <h3 className="font-medium text-zinc-900 dark:text-zinc-100">Links</h3>
             <ul className="mt-2 space-y-1 text-sm">
               <li>
                 <a className="underline" href="https://github.com/migarci2" target="_blank" rel="noreferrer">
@@ -110,4 +103,6 @@ export default function BuilderPage() {
       </section>
     </main>
   );
-}
+};
+
+export default MiguelBuilderPage;

--- a/packages/nextjs/next.config.ts
+++ b/packages/nextjs/next.config.ts
@@ -9,6 +9,18 @@ const nextConfig: NextConfig = {
   eslint: {
     ignoreDuringBuilds: process.env.NEXT_PUBLIC_IGNORE_BUILD_ERROR === "true",
   },
+  images: {
+    remotePatterns: [
+      {
+        protocol: "https",
+        hostname: "github.com",
+      },
+      {
+        protocol: "https",
+        hostname: "avatars.githubusercontent.com",
+      },
+    ],
+  },
   webpack: config => {
     config.resolve.fallback = { fs: false, net: false, tls: false };
     config.externals.push("pino-pretty", "lokijs", "encoding");


### PR DESCRIPTION
## Description

Added my personal builder page for Batch #20.

- Created `packages/nextjs/app/builders/0x8361F86930Eb48f8AA67e86e190dDD7B230E7777/page.tsx`
- Includes avatar, bio, address, focus areas, on-chain info, and links
- Page styled with Tailwind, lightweight and consistent with SE-2 components

Screenshot:  
<img width="1916" height="605" alt="image" src="https://github.com/user-attachments/assets/b028d412-184f-4dc0-9019-5bd471610bb1" />

## Additional Information

- [x] I have read the [contributing docs](/scaffold-eth/scaffold-eth-2/blob/main/CONTRIBUTING.md)  
- [x] This is not a duplicate of any [existing pull request](https://github.com/scaffold-eth/scaffold-eth-2/pulls)

## Related Issues

Closes #9

---

**My address:**  
`0x8361F86930Eb48f8AA67e86e190dDD7B230E7777`
