### PR TITLE
show connected wallet info in address info drowdown component

### DIFF
--- a/packages/nextjs/components/scaffold-eth/RainbowKitCustomConnectButton/AddressInfoDropdown.tsx
+++ b/packages/nextjs/components/scaffold-eth/RainbowKitCustomConnectButton/AddressInfoDropdown.tsx
@@ -4,9 +4,11 @@ import { getAddress } from "viem";
 import { Address } from "viem";
 import { useAccount, useDisconnect } from "wagmi";
 import {
+  AcademicCapIcon,
   ArrowLeftOnRectangleIcon,
   ArrowTopRightOnSquareIcon,
   ArrowsRightLeftIcon,
+  CheckBadgeIcon,
   CheckCircleIcon,
   ChevronDownIcon,
   DocumentDuplicateIcon,
@@ -14,7 +16,7 @@ import {
   QrCodeIcon,
 } from "@heroicons/react/24/outline";
 import { BlockieAvatar, isENS } from "~~/components/scaffold-eth";
-import { useCopyToClipboard, useOutsideClick } from "~~/hooks/scaffold-eth";
+import { useCopyToClipboard, useOutsideClick, useScaffoldReadContract } from "~~/hooks/scaffold-eth";
 import { getTargetNetworks } from "~~/utils/scaffold-eth";
 
 const BURNER_WALLET_ID = "burnerWallet";
@@ -50,6 +52,22 @@ export const AddressInfoDropdown = ({
 
   useOutsideClick(dropdownRef, closeDropdown);
 
+  // fetch member / checked in status of connected wallet
+  const ADDRESS_ZERO = "0x0000000000000000000000000000000000000000";
+  const isBatchMember = useScaffoldReadContract({
+    contractName: "BatchRegistry",
+    functionName: "allowList",
+    args: [checkSumAddress],
+  });
+
+  const yourContractAddress = useScaffoldReadContract({
+    contractName: "BatchRegistry",
+    functionName: "yourContractAddress",
+    args: [checkSumAddress],
+  });
+
+  const isCheckedIn = typeof yourContractAddress.data === "string" && yourContractAddress.data !== ADDRESS_ZERO;
+
   return (
     <>
       <details ref={dropdownRef} className="dropdown dropdown-end leading-3">
@@ -62,6 +80,21 @@ export const AddressInfoDropdown = ({
         </summary>
         <ul className="dropdown-content menu z-2 p-2 mt-2 shadow-center shadow-accent bg-base-200 rounded-box gap-1">
           <NetworkOptions hidden={!selectingNetwork} />
+          <li className={selectingNetwork ? "hidden" : ""}>
+            {isCheckedIn ? (
+              <label htmlFor="wallet-info-modal" className="h-8 btn-sm rounded-xl! flex gap-3 py-3">
+                <CheckBadgeIcon className="h-6 w-4 ml-2 sm:ml-0" />
+                <span className="whitespace-nowrap">Checked In</span>
+              </label>
+            ) : (
+              isBatchMember.data && (
+                <label htmlFor="wallet-info-modal" className="h-8 btn-sm rounded-xl! flex gap-3 py-3">
+                  <AcademicCapIcon className="h-6 w-4 ml-2 sm:ml-0" />
+                  <span className="whitespace-nowrap">Batch 20 Member</span>
+                </label>
+              )
+            )}
+          </li>
           <li className={selectingNetwork ? "hidden" : ""}>
             <div
               className="h-8 btn-sm rounded-xl! flex gap-3 py-3 cursor-pointer"


### PR DESCRIPTION
## Description

Show connected wallet info in the Address Dropdown component on the page header.

If the connected wallet already checked in, it will show additional info like this:

<img width="290" height="277" alt="Screenshot from 2025-09-18 16-11-25" src="https://github.com/user-attachments/assets/8f7cd0e5-9013-4993-b58f-074e250dc344" />

If the connected wallet didn't check in, but already in the allow list, then the drowdown will show this info:

<img width="290" height="277" alt="Screenshot from 2025-09-18 16-12-13" src="https://github.com/user-attachments/assets/c3d09023-eead-4291-8d4e-7915e9329b38" />


## Additional Information

- [x] I have read the [contributing docs](/scaffold-eth/scaffold-eth-2/blob/main/CONTRIBUTING.md) (if this is your first contribution)
- [x] This is not a duplicate of any [existing pull request](https://github.com/scaffold-eth/scaffold-eth-2/pulls)

## Related Issues

_Closes #5_

Your ENS/address: 0x842F32e92D770b3C636DA20A67973A3896D1d9a5
