### PR TITLE
get the check-in count from BatchRegistry contract and display

### DIFF
--- a/packages/nextjs/app/page.tsx
+++ b/packages/nextjs/app/page.tsx
@@ -3,8 +3,14 @@
 import Link from "next/link";
 import type { NextPage } from "next";
 import { BugAntIcon, MagnifyingGlassIcon } from "@heroicons/react/24/outline";
+import { useScaffoldReadContract } from "~~/hooks/scaffold-eth";
 
 const Home: NextPage = () => {
+  const { data: checkedInCounter } = useScaffoldReadContract({
+    contractName: "BatchRegistry",
+    functionName: "checkedInCounter",
+  });
+
   return (
     <>
       <div className="flex items-center flex-col grow pt-10">
@@ -16,7 +22,7 @@ const Home: NextPage = () => {
           <p className="text-center text-lg">Get started by taking a look at your batch GitHub repository.</p>
           <p className="text-lg flex gap-2 justify-center">
             <span className="font-bold">Checked in builders count:</span>
-            <span>To Be Implemented</span>
+            <span>{checkedInCounter}</span>
           </p>
         </div>
 


### PR DESCRIPTION
## Description

Fetch and display the check-in count from BatchRegistry contract

- Dark mode:
<img width="706" height="601" alt="Screenshot from 2025-09-20 18-33-41" src="https://github.com/user-attachments/assets/22cbeffb-929e-4f02-81bd-927fa0ae2c74" />

- Light mode: 
<img width="706" height="601" alt="Screenshot from 2025-09-20 18-36-01" src="https://github.com/user-attachments/assets/602f2bb2-08ec-42c8-aa2b-8321c7a192d5" />


## Additional Information

- [x] I have read the [contributing docs](/scaffold-eth/scaffold-eth-2/blob/main/CONTRIBUTING.md) (if this is your first contribution)
- [x] This is not a duplicate of any [existing pull request](https://github.com/scaffold-eth/scaffold-eth-2/pulls)

## Related Issues

_Closes #6_

Your ENS/address: 0xnetero.eth
