### PR TITLE
feat: add MembershipStatus component to display user membership details

### DIFF
--- a/packages/nextjs/components/scaffold-eth/MembershipStatus.tsx
+++ b/packages/nextjs/components/scaffold-eth/MembershipStatus.tsx
@@ -1,0 +1,44 @@
+"use client";
+
+import { Address, zeroAddress } from "viem";
+import { CheckBadgeIcon, UserCircleIcon } from "@heroicons/react/24/solid";
+import { useScaffoldReadContract } from "~~/hooks/scaffold-eth";
+
+interface MembershipStatusProps {
+  address: Address;
+}
+
+export const MembershipStatus = ({ address }: MembershipStatusProps) => {
+  const { data: isAllowListed } = useScaffoldReadContract({
+    contractName: "BatchRegistry",
+    functionName: "allowList",
+    args: [address],
+  });
+
+  const { data: contractAddress } = useScaffoldReadContract({
+    contractName: "BatchRegistry",
+    functionName: "yourContractAddress",
+    args: [address],
+  });
+
+  const isCheckedIn = contractAddress && contractAddress !== zeroAddress;
+
+  if (!isAllowListed) return null;
+
+  return (
+    <div className="flex items-center mr-1">
+      <div
+        className="tooltip tooltip-bottom"
+        data-tip={isCheckedIn ? "Batch Member - Checked In" : "Batch Member - Not Checked In"}
+      >
+        <div className="flex items-center">
+          {isCheckedIn ? (
+            <CheckBadgeIcon className="h-4 w-4 text-success" />
+          ) : (
+            <UserCircleIcon className="h-4 w-4 text-warning" />
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/packages/nextjs/components/scaffold-eth/RainbowKitCustomConnectButton/index.tsx
+++ b/packages/nextjs/components/scaffold-eth/RainbowKitCustomConnectButton/index.tsx
@@ -2,6 +2,7 @@
 
 // @refresh reset
 import { Balance } from "../Balance";
+import { MembershipStatus } from "../MembershipStatus";
 import { AddressInfoDropdown } from "./AddressInfoDropdown";
 import { AddressQRCodeModal } from "./AddressQRCodeModal";
 import { RevealBurnerPKModal } from "./RevealBurnerPKModal";
@@ -44,6 +45,7 @@ export const RainbowKitCustomConnectButton = () => {
 
               return (
                 <>
+                  <MembershipStatus address={account.address as Address} />
                   <div className="flex flex-col items-center mr-1">
                     <Balance address={account.address as Address} className="min-h-0 h-auto" />
                     <span className="text-xs" style={{ color: networkColor }}>


### PR DESCRIPTION
## Description

Adds membership status indicators in the header. When a user connects their wallet, they will see a single icon next to their address that shows:

- Green CheckBadgeIcon: Batch member who has checked in
  <img width="366" height="151" alt="image" src="https://github.com/user-attachments/assets/f5fd35d7-2f98-4bac-9813-ddb2892c7c96" />

- Orange UserCircleIcon: Batch member who hasn't checked in yet
  <img width="366" height="151" alt="image" src="https://github.com/user-attachments/assets/7e6b89e7-f154-4f00-9a0f-d129bb1afdd6" />

- No icon: Not a batch member
  <img width="366" height="151" alt="image" src="https://github.com/user-attachments/assets/c9169415-5fa4-4b5f-ac18-506f2f76d8ac" />

The component reads from the BatchRegistry contract to check the allowList mapping (for membership) and yourContractAddress mapping (for check-in status). Uses a single icon approach for cleaner UI and includes tooltips with detailed status information.

## Additional Information

- [x] I have read the [contributing docs](/scaffold-eth/scaffold-eth-2/blob/main/CONTRIBUTING.md) (if this is your first contribution)
- [x] This is not a duplicate of any [existing pull request](https://github.com/scaffold-eth/scaffold-eth-2/pulls)

## Related Issues

_Closes #5_

Your ENS/address: ```0x7b32DF263625bFCC9EdF743A382b81c2e1A567Ec```
